### PR TITLE
Improve script to dynamically retrieve simulator device ID 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,39 @@
-# Why?
+# Open iOS Preferences Script
 
-When working in iOS with user preferences sometimes we need to quickly reset them. I found an [article](https://pradnya-nikam.medium.com/view-and-change-user-defaults-on-ios-simulator-d2c3fc3b82b1) about how to do it. Doing it manually kind of get tedious.
+This script allows you to automatically open the preferences `.plist` file of an iOS app running in a simulator. It dynamically retrieves the simulator's device ID and the app's bundle identifier (`CFBundleIdentifier`) without requiring manual input.
 
-So I did this short script, it has to be run for every install (new installs from XCode change the name of the installation folder).
+## Requirements
 
-# How?
+- macOS
+- Xcode Command Line Tools
+- A booted iOS simulator
 
-Download the script and then run it with two arguments:
+## How It Works
 
- - Device ID
- - Application bundle ID
+The script:
+1. Retrieves the `DEVICE_ID` of the currently booted iOS simulator.
+2. Automatically identifies the `.plist` file associated with the app’s `CFBundleIdentifier` inside the simulator’s directory.
+3. Opens the `.plist` file for viewing or editing.
 
-For example:
+## Usage
 
-```
-bash ios_open_preferences.sh FEFD68AF-D256-4GHC-99EE-98810E9L8160 com.company.AppName
-```
+### Running the Script
+
+1. Clone this repository or copy the script to your local machine.
+2. Make sure the script is executable. You can use the following command:
+
+    ```bash
+    chmod +x open_preferences.sh
+    ```
+
+3. Run the script while your iOS app is running in the simulator:
+
+    ```bash
+    ./open_preferences.sh
+    ```
+
+The script will automatically find and open the `.plist` file for the running app in the simulator.
+
+### Customizing the App Bundle Identifier
+
+By default, the script attempts to read the app's `CFBundleIdentifier` fr

--- a/ios_open_preferences.sh
+++ b/ios_open_preferences.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Get the identifier of the active simulator using simctl
-DEVICE_ID=$(xcrun simctl list devices | grep -m1 "(Booted)" | awk '{print $2}' | tr -d '()')
+# Adjusted to capture the fourth column which is the actual device ID (UUID)
+DEVICE_ID=$(xcrun simctl list devices | grep -m1 "(Booted)" | awk '{print $4}' | tr -d '()')
 
 # Check if the device ID was found correctly
 if [ -z "$DEVICE_ID" ]; then
@@ -26,5 +27,10 @@ fi
 
 # Find and open the plist file on the simulator device
 find . -name "$PLIST_NAME.plist" | while read -r preferencesFile; do
-    open "$preferencesFile"
+    if [ -f "$preferencesFile" ]; then
+        open "$preferencesFile"
+    else
+        echo "Plist file not found."
+        exit 1
+    fi
 done

--- a/ios_open_preferences.sh
+++ b/ios_open_preferences.sh
@@ -1,7 +1,30 @@
 #!/bin/bash
 
-cd ~/Library/Developer/CoreSimulator/Devices/$1
+# Get the identifier of the active simulator using simctl
+DEVICE_ID=$(xcrun simctl list devices | grep -m1 "(Booted)" | awk '{print $2}' | tr -d '()')
 
-find . -name $2.plist | while read preferencesFile; do
-    open $preferencesFile
+# Check if the device ID was found correctly
+if [ -z "$DEVICE_ID" ]; then
+    echo "No active simulator found."
+    exit 1
+fi
+
+# Change to the directory of the active simulator
+cd ~/Library/Developer/CoreSimulator/Devices/$DEVICE_ID || {
+    echo "Could not access simulator directory: $DEVICE_ID"
+    exit 1
+}
+
+# Retrieve the name of the plist file from a project file (e.g., Info.plist from your project)
+PLIST_NAME=$(defaults read "$(pwd)/data/Containers/Data/Application" CFBundleIdentifier 2>/dev/null || echo "DefaultPlistName")
+
+# Check if the plist file name was found
+if [ -z "$PLIST_NAME" ]; then
+    echo "No plist file name found."
+    exit 1
+fi
+
+# Find and open the plist file on the simulator device
+find . -name "$PLIST_NAME.plist" | while read -r preferencesFile; do
+    open "$preferencesFile"
 done


### PR DESCRIPTION
feat: Improve script to dynamically retrieve simulator device ID and app's plist file

- Added logic to automatically detect the booted iOS simulator using `xcrun simctl` and retrieve its DEVICE_ID, removing the need for manual input.
- Implemented dynamic retrieval of the app’s CFBundleIdentifier from the app’s directory or defaults to "DefaultPlistName" if not found.
- Improved error handling for cases when the simulator or plist file cannot be found.
- Updated the script to automatically open the corresponding plist file within the simulator directory.
- Enhanced the script to make it more user-friendly, eliminating manual steps.
